### PR TITLE
chore: some better experiences

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ```bash
 # 下载脚本时的相关依赖
-sudo apt update && apt -y install git curl
+sudo apt update && sudo apt -y install git curl
 
 # 执行脚本，开始添加 PVE_State_Tools
 sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/install.sh)"

--- a/README.md
+++ b/README.md
@@ -10,18 +10,28 @@
 
 > 注意:需要使用`root`身份执行下面代码
 
-*在终端中按行分别执行以下代码：*
-```
-export LC_ALL=en_US.UTF-8
-apt update && apt -y install git && git clone https://github.com/iKoolCore/PVE_Status_Tools.git
-cd PVE_Status_Tools
-bash ./PVE_Status_Tools.sh
+
+```bash
+# 下载脚本时的相关依赖
+sudo apt update && apt -y install git curl
+
+# 执行脚本，开始添加 PVE_State_Tools
+sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/install.sh)"
 ```
 
-**或**  *直接执行下面一行代码：*
+如果发现 `curl: (7) Failed to connect to raw.githubusercontent.com port 443: Connection refused` 这种错误
+
+年轻人，你的网络运营商屏蔽了 GitHub
+
+可以使用如下方法尝试:
+
+```bash
+# 例子: HTTPS_PROXY=http://127.0.0.1:8081
+# 小写变量名字也是可以的
+
+sudo HTTPS_PROXY=你的代理地址 sh -c "$(curl -fsSL https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/install.sh)"
 ```
-wget -qO-  https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/PVE_Status_Tools.sh | bash
-```
+
 #### 二、还原方法：
 方法① ：
 用压缩包中对应文件`（PVE 7.2-3）`的原版覆盖，再重启 `pveproxy服务`： <br>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+export LC_ALL=en_US.UTF-8
+
+if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+    echo "Not running as root"
+    exit
+fi
+
+_exists() {
+  cmd="$1"
+  if [ -z "$cmd" ] ; then
+    echo "Usage: _exists cmd"
+    return 1
+  fi
+  if type command >/dev/null 2>&1 ; then
+    command -v $cmd >/dev/null 2>&1
+  else
+    type $cmd >/dev/null 2>&1
+  fi
+  ret="$?"
+  return $ret
+}
+
+SCRIPT_URL="https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/PVE_Status_Tools.sh"
+
+if _exists curl ; then
+  curl $INSTALL_URL | bash
+elif _exists wget ; then
+  wget -O - $INSTALL_URL | bash
+else
+  echo "Sorry, you must have curl or wget installed first."
+  echo "Please install either of them and try again."
+fi

--- a/install.sh
+++ b/install.sh
@@ -22,12 +22,12 @@ _exists() {
   return $ret
 }
 
-SCRIPT_URL="https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/PVE_Status_Tools.sh"
+TOOLS_URL="https://raw.githubusercontent.com/iKoolCore/PVE_Status_Tools/main/PVE_Status_Tools.sh"
 
 if _exists curl ; then
-  curl $INSTALL_URL | bash
+  curl $TOOLS_URL | bash
 elif _exists wget ; then
-  wget -O - $INSTALL_URL | bash
+  wget -O - $TOOLS_URL | bash
 else
   echo "Sorry, you must have curl or wget installed first."
   echo "Please install either of them and try again."


### PR DESCRIPTION
### BUG

如果没有安装过 `iostat`，不会安装 `sysstat`，以至于后面查询硬盘相关信息的步骤出现错误。

### 体验优化

1. 企业订阅源 **pve-enterprise.list** 可以添加 `.bak` 后缀，达到不作为更新源的目的
2. PVE内核源 作为单独的源文件放置到 `/etc/apt/sources.list.d/` 目录更好，也避免重复追加到 `/etc/apt/sources.list` 尾部
3. PVE内核源 使用较为广泛的清华源，安装速度会有明显提升，不至于因为网络状况而心烦意乱
4. 一键安装脚本
